### PR TITLE
Skips text layouting during parsing in usvg if preserve-text argument is present

### DIFF
--- a/crates/resvg/src/main.rs
+++ b/crates/resvg/src/main.rs
@@ -578,6 +578,7 @@ fn parse_args() -> Result<Args, String> {
         font_resolver: usvg::FontResolver::default(),
         fontdb: Arc::new(fontdb::Database::new()),
         style_sheet,
+        preserve_text: false,
     };
 
     Ok(Args {

--- a/crates/usvg/src/main.rs
+++ b/crates/usvg/src/main.rs
@@ -432,6 +432,7 @@ fn process(args: Args) -> Result<(), String> {
         font_resolver: usvg::FontResolver::default(),
         fontdb: Arc::new(fontdb),
         style_sheet,
+        preserve_text: args.preserve_text,
     };
 
     let input_svg = match in_svg {

--- a/crates/usvg/src/parser/options.rs
+++ b/crates/usvg/src/parser/options.rs
@@ -102,6 +102,9 @@ pub struct Options<'a> {
     /// Specifies whether to convert text nodes to paths. If true, will skip text
     /// layout and rendering during parsing and ignores fonts. It mirrors
     /// `preserve_text` in `usvg::writer::Options`.
+    ///
+    /// Warning: This may cause rendering issues with elements that depend on proper text
+    /// layout, such as those using `objectBoundingBox` units.
     pub preserve_text: bool,
 }
 

--- a/crates/usvg/src/parser/options.rs
+++ b/crates/usvg/src/parser/options.rs
@@ -98,6 +98,11 @@ pub struct Options<'a> {
     /// A CSS stylesheet that should be injected into the SVG. Can be used to overwrite
     /// certain attributes.
     pub style_sheet: Option<String>,
+
+    /// Specifies whether to convert text nodes to paths. If true, will skip text
+    /// layout and rendering during parsing and ignores fonts. It mirrors
+    /// `preserve_text` in `usvg::writer::Options`.
+    pub preserve_text: bool,
 }
 
 impl Default for Options<'_> {
@@ -119,6 +124,7 @@ impl Default for Options<'_> {
             #[cfg(feature = "text")]
             fontdb: Arc::new(fontdb::Database::new()),
             style_sheet: None,
+            preserve_text: false,
         }
     }
 }

--- a/crates/usvg/src/parser/text.rs
+++ b/crates/usvg/src/parser/text.rs
@@ -140,7 +140,9 @@ pub(crate) fn convert(
         layouted: vec![],
     };
 
-    if !state.opt.preserve_text && text::convert(&mut text, &state.opt.font_resolver, &mut cache.fontdb).is_none() {
+    if !state.opt.preserve_text
+        && text::convert(&mut text, &state.opt.font_resolver, &mut cache.fontdb).is_none()
+    {
         return;
     }
 

--- a/crates/usvg/src/parser/text.rs
+++ b/crates/usvg/src/parser/text.rs
@@ -140,7 +140,7 @@ pub(crate) fn convert(
         layouted: vec![],
     };
 
-    if text::convert(&mut text, &state.opt.font_resolver, &mut cache.fontdb).is_none() {
+    if !state.opt.preserve_text && text::convert(&mut text, &state.opt.font_resolver, &mut cache.fontdb).is_none() {
         return;
     }
 

--- a/crates/usvg/tests/write.rs
+++ b/crates/usvg/tests/write.rs
@@ -34,6 +34,7 @@ fn resave_impl(name: &str, id_prefix: Option<String>, preserve_text: bool) {
     let tree = {
         let opt = usvg::Options {
             fontdb: GLOBAL_FONTDB.clone(),
+            preserve_text,
             ..Default::default()
         };
         usvg::Tree::from_str(&input_svg, &opt).unwrap()


### PR DESCRIPTION
Updates usvg to ignore text layouting if `--preserve-text` argument is passed in the CLI. This prevents missing fonts from causing usvg to skip text nodes entirely.

Wasn't able to get this merged [upstream](https://github.com/linebender/resvg/pull/918) as there were concerns that this could cause rendering issues (e.g. `objectBoundingBox` units require all nodes to be laid out correctly, hence text layout is needed).

This is a workaround as we need to run usvg before fonts are available.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an option to preserve text elements in SVG files, allowing users to choose whether text is kept as text or converted to paths during processing.

- **Bug Fixes**
  - Improved handling of text elements to ensure the preserve text option is consistently applied during SVG parsing and rendering.

- **Tests**
  - Updated tests to verify correct behavior when the preserve text option is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->